### PR TITLE
Wrap non-changed elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The `renderChange` prop lets you do this:
   renderChange={({ type, children }) => 
     type === 'added'
     ? <Added>{children}</Added>
-    : <Removed>{children}</Removed>}
+    : type === 'removed' 
+      ?<Removed>{children}</Removed>}
+      : children
   />
 ```
 
@@ -77,7 +79,7 @@ This would only render differences of the children prop.
 | - | - | - | - |
 | `left` | `React.Element` | required | Pass React.Element or just jsx `left={<MyFancyComponent>}` |
 | `right` | `React.Element` | required | Pass React.Element or just jsx `right={<MyOtherFancyComponent>}` |
-| `renderChange` | `Component<{ type: 'added' | 'removed', children: React$Children }>` | optional | A react component (can be just a function) that takes two props, `type` is the type of change (`"added"` or `"removed"`), `children` is just the content of the change |
+| `renderChange` | `Component<{ type: 'added' | 'removed' | undefined, children: React$Children }>` | optional | A react component (can be just a function) that takes two props, `type` is the type of change (`"added"`, `"removed"`, or `undefined`), `children` is just the content of the change |
 | `diffProps` | `Array<string>` | optional | An array of prop names that will be diffed. defaults to `['children', 'type', 'className', 'style']` |
 
 ### Roadmap

--- a/src/index.js
+++ b/src/index.js
@@ -18,15 +18,16 @@ const blockElements = ['div', 'hr', 'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'p']
 const renderChange = ({ type, children }) => {
   if (children == null) {
     return null;
-  } 
+  }
+
   if (children != null && blockElements.includes(children.type)) {
     return <div
-      style={type === 'added' ? addedBlock : removedBlock}
+      style={type === 'added' ? addedBlock : type === 'removed' ? removedBlock : {}}
     >{children}</div>;
   }
 
   return <span
-    style={type === 'added' ? addedInline : removedInline}
+    style={type === 'added' ? addedInline : type === 'removed' ? removedInline : {}}
   >{children}</span>;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,12 @@ const reduceChange = (acc, { path, diffType, value, left, right}) => {
           }
         }
       } else {
-        return item.value
+        return {
+          type: 'span',
+          props:{
+            children: item.value
+          }
+        }
       }
     })
     return set(acc, path, value)

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -126,7 +126,13 @@ const renderChild = (child, renderChange) => {
   } else if (Array.isArray(child)) {
     return renderChildren(child, renderChange)
   } else {
-    return child
+    return React.createElement(
+      renderChange,
+      {
+        children: child,
+        key: `key-child-${i++}`
+      }
+    )
   }
 }
 


### PR DESCRIPTION
Currently, any elements that are not changed lie in the DOM as a text node surrounded by other Span and Div elements, which introduces difficulty when applying styling to all parts of the visualized diffs. This simply wraps the non-changed elements in a span tag with no styling applied.